### PR TITLE
Update pipeline to not publish on PR

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -5,9 +5,7 @@ trigger:
       - master
       - release/*
 
-pr:
-  - master
-  - release/*
+pr: none
 
 variables:
   nodeVersion: 15.x


### PR DESCRIPTION
Just like https://github.com/w-pay/sdk-wpay-js/commit/9ead5a1d0f8b9144ed0f9a67490e2c4657b4e297#diff-9eedc1d7d657ddb36b1105a0fffb4852f6d34e26454371f27b6e0ad1391f290e we don't want modules to be published until they're merged into master.